### PR TITLE
[YS-7371] Fix Zenject crash on Android

### DIFF
--- a/UnityProject/Assets/Plugins/Zenject/Source/Runtime/Kernels/ProjectKernel.cs
+++ b/UnityProject/Assets/Plugins/Zenject/Source/Runtime/Kernels/ProjectKernel.cs
@@ -36,8 +36,7 @@ namespace Zenject
             ForceUnloadAllScenes(true);
 
             Assert.That(!IsDestroyed);
-            GameObject.DestroyImmediate(this.gameObject);
-            Assert.That(IsDestroyed);
+            GameObject.Destroy(this.gameObject);
         }
 
         public void ForceUnloadAllScenes(bool immediate = false)


### PR DESCRIPTION
I applied the fix discussed [here](https://github.com/modesttree/Zenject/issues/301). Although we only saw this crash on some Android platforms, I applied the fix across the board as I don't see any counter-indications to it.