### PR TITLE
[Inject] means [UsedImplicitly]

### DIFF
--- a/UnityProject/Assets/Plugins/Zenject/Source/Usage/Zenject-usage.ExternalAnnotations.xml
+++ b/UnityProject/Assets/Plugins/Zenject/Source/Usage/Zenject-usage.ExternalAnnotations.xml
@@ -1,0 +1,7 @@
+<assembly name="Zenject-usage">
+  <member name="T:Zenject.InjectAttribute">
+    <attribute ctor="M:JetBrains.Annotations.MeansImplicitUseAttribute.#ctor(JetBrains.Annotations.ImplicitUseKindFlags)">
+      <argument>2</argument>
+    </attribute>
+  </member>
+</assembly>

--- a/UnityProject/Assets/Plugins/Zenject/Source/Usage/Zenject-usage.ExternalAnnotations.xml
+++ b/UnityProject/Assets/Plugins/Zenject/Source/Usage/Zenject-usage.ExternalAnnotations.xml
@@ -1,3 +1,4 @@
+<!-- This file can be removed after upgrading Zenject to 8.0.0 or later -->
 <assembly name="Zenject-usage">
   <member name="T:Zenject.InjectAttribute">
     <attribute ctor="M:JetBrains.Annotations.MeansImplicitUseAttribute.#ctor(JetBrains.Annotations.ImplicitUseKindFlags)">

--- a/UnityProject/Assets/Plugins/Zenject/Source/Usage/Zenject-usage.ExternalAnnotations.xml.meta
+++ b/UnityProject/Assets/Plugins/Zenject/Source/Usage/Zenject-usage.ExternalAnnotations.xml.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 68e2f10df6d7e4fa6bb81eeba830b3d9
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
- Rider won't complain about unassigned members
  - Only assignment is implied (same as `[UsedImplicitly(ImplicitUseKindFlags.Assign)]`)
- Done by adding a `MeansImplicitUse` attribute to the `Inject` attribute via a Resharper external annotations file