### PR TITLE
Fix define constraints on Zenject-TestFramework

### DIFF
--- a/UnityProject/Assets/Plugins/Zenject/Source/Editor/TestFramework/Zenject-TestFramework.asmdef
+++ b/UnityProject/Assets/Plugins/Zenject/Source/Editor/TestFramework/Zenject-TestFramework.asmdef
@@ -13,7 +13,7 @@
         "nunit.framework.dll"
     ],
     "autoReferenced": false,
-    "defineConstraints": [],
+    "defineConstraints": [ "UNITY_INCLUDE_TESTS" ],
     "versionDefines": [],
     "noEngineReferences": false
 }


### PR DESCRIPTION
Adds `UNITY_INCLUDE_TESTS` define constraint in `Zenject-TestFramework.asmdef`, as we shouldn't be including the test framework in non-test Player builds.