### PR TITLE
Validate `IValidatable` per-instance instead of per-type

### DIFF
--- a/UnityProject/Assets/Plugins/Zenject/Source/Runtime/Main/DiContainer.cs
+++ b/UnityProject/Assets/Plugins/Zenject/Source/Runtime/Main/DiContainer.cs
@@ -193,7 +193,7 @@ namespace Zenject
         {
             if (_hasResolvedRoots)
             {
-				Log.Error($"Trying to queue '{validatable.GetType().PrettyName()}' for validation after resolving");
+                Log.Error($"Trying to queue '{validatable.GetType().PrettyName()}' for validation after resolving");
             }
             else
             {

--- a/UnityProject/Assets/Plugins/Zenject/Source/Runtime/Main/DiContainer.cs
+++ b/UnityProject/Assets/Plugins/Zenject/Source/Runtime/Main/DiContainer.cs
@@ -34,7 +34,6 @@ namespace Zenject
         readonly Queue<BindStatement> _currentBindings = new Queue<BindStatement>();
         readonly List<BindStatement> _childBindings = new List<BindStatement>();
 
-        readonly HashSet<Type> _validatedTypes = new HashSet<Type>();
         readonly List<IValidatable> _validationQueue = new List<IValidatable>();
 
 #if !NOT_UNITY3D
@@ -192,16 +191,13 @@ namespace Zenject
 
         public void QueueForValidate(IValidatable validatable)
         {
-            // Don't bother adding to queue if the initial resolve is already completed
-            if (!_hasResolvedRoots)
+            if (_hasResolvedRoots)
             {
-                var concreteType = validatable.GetType();
-
-                if (!_validatedTypes.Contains(concreteType))
-                {
-                    _validatedTypes.Add(concreteType);
-                    _validationQueue.Add(validatable);
-                }
+				Log.Error($"Trying to queue '{validatable.GetType().PrettyName()}' for validation after resolving");
+            }
+            else
+            {
+                _validationQueue.Add(validatable);
             }
         }
 


### PR DESCRIPTION
Validate `IValidatable` per-instance instead of per-type. This is required to properly validate things set up in prefabs. Also log error instead of silently skipping validation if `QueueForValidate` is called too late.