### PR TITLE
Print meaningful object graph for Unity components

### DIFF
--- a/UnityProject/Assets/Plugins/Zenject/Source/Runtime/Injection/InjectContext.cs
+++ b/UnityProject/Assets/Plugins/Zenject/Source/Runtime/Injection/InjectContext.cs
@@ -268,6 +268,28 @@ namespace Zenject
                 result.AppendLine(context.ObjectType.PrettyName());
             }
 
+#if !NOT_UNITY3D
+            if (this.ObjectInstance is UnityEngine.Component component)
+            {
+                // Print the GameObject hierarchy
+                var transform = component.transform;
+                while (transform != null)
+                {
+                    if (transform.name.EndsWith("(Clone)"))
+                    {
+                        // Stop printing when we find an instantiated object, we are validating that prefab
+                        result.AppendLine(transform.name.Replace("(Clone)", " (prefab)"));
+                        break;
+                    }
+                    else
+                    {
+                        result.AppendLine(transform.name);
+                        transform = transform.parent;
+                    }
+                }
+            }
+#endif
+
             return result.ToString();
         }
     }

--- a/UnityProject/Assets/Plugins/Zenject/Source/Runtime/Providers/SubContainerCreators/SubContainerCreatorCached.cs
+++ b/UnityProject/Assets/Plugins/Zenject/Source/Runtime/Providers/SubContainerCreators/SubContainerCreatorCached.cs
@@ -34,8 +34,10 @@ namespace Zenject
                 if (_subContainer == null)
                 {
 #if !ZEN_MULTITHREADING
-                    Assert.That(!_isLookingUp,
-                        "Found unresolvable circular dependency when looking up sub container!  Object graph:\n {0}", context.GetObjectGraphString());
+                    if (this._isLookingUp)
+                    {
+                        Assert.That(false, "Found unresolvable circular dependency when looking up sub container!  Object graph:\n {0}", context.GetObjectGraphString());
+                    }
                     _isLookingUp = true;
 #endif
 
@@ -48,7 +50,7 @@ namespace Zenject
 
                     Assert.IsNotNull(_subContainer);
                 }
-                else 
+                else
                 {
                     injectAction = null;
                 }


### PR DESCRIPTION
The object graph used to be just a one-liner in many cases:
```
SomeComponent
```

Now when prefabs are being validated, it will look like this:
```
SomeComponent
Parent
NameOfPrefab (prefab)
```

This makes it clear which component in which prefab failed the validation, which is especially useful for reusable components.